### PR TITLE
added a timer that starts on first click

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -7,7 +7,11 @@ import grid from "../utils/fillBoard";
 class App extends Component {
   state = {
     grid: [],
-    status: "alive"
+    status: "alive",
+    minutes: 0,
+    seconds: 0,
+    zeroPlace: 0,
+    timerOn: false
   };
 
   clicked = (i, j) => {
@@ -23,6 +27,28 @@ class App extends Component {
     this.setState({
       grid
     });
+
+    if (this.state.timerOn === false) {
+      this.timer = setInterval(() => {
+        // reset seconds every minute and add one minute
+        if (this.state.seconds != 0 && this.state.seconds % 59 === 0) {
+          this.setState({ minutes: this.state.minutes+1, seconds: -1 })
+        }
+        // remove zero place after 9 seconds
+        if (this.state.seconds >= 9) {
+          this.setState({ zeroPlace: '' })
+        }
+        // add zero place if seconds are less than 10
+        if (this.state.seconds < 9) {
+          this.setState({ zeroPlace: 0 })
+        }
+        // add one second every second,
+        // and turn timerOn to true so interval will not run every time someone clicks.
+        this.setState({
+        seconds: this.state.seconds+1,
+        timerOn: true
+      })}, 1000)
+    }
   };
 
   setFlag = (i,j) => {
@@ -68,6 +94,7 @@ class App extends Component {
     return (
       <div>
         <h1>{this.state.status}</h1>
+        <h1>minutes: {this.state.minutes}:{this.state.zeroPlace}{this.state.seconds}</h1>
         <Board
           grid={this.state.grid}
           clicked={this.clicked}


### PR DESCRIPTION
I added a timer that starts when the user first clicks a square.
Since the timer renders on the screen one second after setState is called, some additonal logic needed to be added.  This timer: 
// reset seconds every minute and add one minute
// remove zero place after 9 seconds
// add zero place if seconds are less than 10
// add one second every second,
// and turn timerOn to true so interval will not run every time someone clicks.